### PR TITLE
Feature - invertible image shader

### DIFF
--- a/cryoet_data_portal_neuroglancer/models/json_generator.py
+++ b/cryoet_data_portal_neuroglancer/models/json_generator.py
@@ -198,7 +198,6 @@ class SegmentationJSONGenerator(RenderingJSONGenerator):
 class ImageVolumeJSONGenerator(RenderingJSONGenerator):
     """Generates JSON Neuroglancer config for volume rendering."""
 
-    color: str
     rendering_depth: int  # Ideally, this should be a power of 2
     contrast_limits: tuple[float, float] = (-64, 64)
     threedee_contrast_limits: tuple[float, float] = (-64, 64)
@@ -208,11 +207,9 @@ class ImageVolumeJSONGenerator(RenderingJSONGenerator):
         self._type = RenderingTypes.IMAGE
 
     def _get_shader(self) -> dict[str, Any]:
-        # TODO (skm) - verify expected color usage
         shader_builder = ImageVolumeShaderBuilder(
             contrast_limits=self.contrast_limits,
             threedee_contrast_limits=self.threedee_contrast_limits,
-            default_color=self.color,
         )
         return shader_builder.build_shader()
 

--- a/cryoet_data_portal_neuroglancer/models/json_generator.py
+++ b/cryoet_data_portal_neuroglancer/models/json_generator.py
@@ -93,14 +93,14 @@ class ImageJSONGenerator(RenderingJSONGenerator):
         # At the moment these are the same limits,
         # but in the future the calculation might change for 3D rendering
         if self.has_volume_rendering_shader:
-            shader_builder = ImageShaderBuilder(
-                contrast_limits=contrast_limits,
-            )
-        else:
             threedee_contrast_limits = contrast_limits
             shader_builder = ImageWithVolumeRenderingShaderBuilder(
                 contrast_limits=contrast_limits,
                 threedee_contrast_limits=threedee_contrast_limits,
+            )
+        else:
+            shader_builder = ImageShaderBuilder(
+                contrast_limits=contrast_limits,
             )
         return shader_builder.build_shader()
 

--- a/cryoet_data_portal_neuroglancer/models/json_generator.py
+++ b/cryoet_data_portal_neuroglancer/models/json_generator.py
@@ -199,7 +199,7 @@ class ImageVolumeJSONGenerator(RenderingJSONGenerator):
     """Generates JSON Neuroglancer config for volume rendering."""
 
     color: str
-    rendering_depth: int # Ideally, this should be a power of 2
+    rendering_depth: int  # Ideally, this should be a power of 2
     contrast_limits: tuple[float, float] = (-64, 64)
     threedee_contrast_limits: tuple[float, float] = (-64, 64)
     is_visible: bool = True

--- a/cryoet_data_portal_neuroglancer/models/json_generator.py
+++ b/cryoet_data_portal_neuroglancer/models/json_generator.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import numpy as np
 
-from cryoet_data_portal_neuroglancer.models.shader_builder import ImageShaderBuilder
+from cryoet_data_portal_neuroglancer.shaders.shader_builder import ImageShaderBuilder
 
 
 def create_source(

--- a/cryoet_data_portal_neuroglancer/models/json_generator.py
+++ b/cryoet_data_portal_neuroglancer/models/json_generator.py
@@ -90,9 +90,9 @@ class ImageJSONGenerator(RenderingJSONGenerator):
 
     def _create_shader_and_controls(self) -> dict[str, Any]:
         contrast_limits = self._compute_contrast_limits()
-        # At the moment these are the same limits,
-        # but in the future the calculation might change for 3D rendering
         if self.has_volume_rendering_shader:
+            # At the moment these are the same limits,
+            # but in the future the calculation might change for 3D rendering
             threedee_contrast_limits = contrast_limits
             shader_builder = ImageWithVolumeRenderingShaderBuilder(
                 contrast_limits=contrast_limits,

--- a/cryoet_data_portal_neuroglancer/models/json_generator.py
+++ b/cryoet_data_portal_neuroglancer/models/json_generator.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import numpy as np
 
+from cryoet_data_portal_neuroglancer.utils import get_window_limits_from_contrast_limits
+
 
 def create_source(
     url: str,
@@ -80,12 +82,11 @@ class ImageJSONGenerator(RenderingJSONGenerator):
 
     def _create_shader_and_controls(self) -> dict[str, Any]:
         if self.mean is None or self.rms is None:
-            distance = self.contrast_limits[1] - self.contrast_limits[0]
-            window_start = self.contrast_limits[0] - (distance / 10)
-            window_end = self.contrast_limits[1] + (distance / 10)
+            print("hellloo")
+            window_limits = get_window_limits_from_contrast_limits(self.contrast_limits)
             shader = (
                 f"#uicontrol invlerp contrast(range=[{self.contrast_limits[0]}, {self.contrast_limits[1]}], "
-                f"window=[{window_start}, {window_end}])\nvoid main() {{\n  emitGrayscale(contrast());\n}}"
+                f"window=[{window_limits[0]}, {window_limits[1]}])\nvoid main() {{\n  emitGrayscale(contrast());\n}}"
             )
             return {"shader": shader}
 

--- a/cryoet_data_portal_neuroglancer/models/json_generator.py
+++ b/cryoet_data_portal_neuroglancer/models/json_generator.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import numpy as np
 
-from cryoet_data_portal_neuroglancer.shaders.shader_builder import ImageShaderBuilder
+from cryoet_data_portal_neuroglancer.shaders.image import ImageShaderBuilder
 
 
 def create_source(

--- a/cryoet_data_portal_neuroglancer/models/json_generator.py
+++ b/cryoet_data_portal_neuroglancer/models/json_generator.py
@@ -102,7 +102,7 @@ class ImageJSONGenerator(RenderingJSONGenerator):
             shader_builder = ImageShaderBuilder(
                 contrast_limits=contrast_limits,
             )
-        return shader_builder.build_shader()
+        return shader_builder.build()
 
     def _get_computed_values(self) -> dict[str, Any]:
         nstart = self.start or {k: 0 for k in "xyz"}

--- a/cryoet_data_portal_neuroglancer/models/json_generator.py
+++ b/cryoet_data_portal_neuroglancer/models/json_generator.py
@@ -76,7 +76,7 @@ class ImageJSONGenerator(RenderingJSONGenerator):
     mean: float = None
     rms: float = None
     is_visible: bool = True
-    volume_rendering_depth_samples: int = 512  # Ideally, this should be a power of 2
+    volume_rendering_depth_samples: int = 256  # Ideally, this should be a power of 2
 
     def __post_init__(self):
         self._type = RenderingTypes.IMAGE

--- a/cryoet_data_portal_neuroglancer/models/shader_builder.py
+++ b/cryoet_data_portal_neuroglancer/models/shader_builder.py
@@ -72,8 +72,12 @@ class ShaderBuilder:
     ) -> list[str]:
         invlerp_component = self.make_invlerp_component(name, contrast_limits, window_limits)
         checkbox_part = f"#uicontrol bool invert_{name} checkbox"
-        data_value_getter = f"float {name}_get() {{ return invert_{name} ? 1.0 - {name}() : {name}(); }}"
-        return [invlerp_component, checkbox_part, data_value_getter]
+        data_value_getter = [
+            f"float {name}_get()" + " {",
+            f"{TAB}return invert_{name} ? 1.0 - {name}() : {name}();",
+            "}",
+        ]
+        return [invlerp_component, checkbox_part, *data_value_getter]
 
     def make_color_component(self, name: str, default_color: str) -> str:
         self._shader_controls[name] = default_color

--- a/cryoet_data_portal_neuroglancer/models/shader_builder.py
+++ b/cryoet_data_portal_neuroglancer/models/shader_builder.py
@@ -120,8 +120,8 @@ class ImageVolumeShaderBuilder(ShaderBuilder):
 
     def _add_cross_section_and_vr_code(
         self,
-        volume_rendering_code: list[str],
-        cross_section_code: list[str],
+        volume_rendering_code: str | list[str],
+        cross_section_code: str | list[str],
     ):
         self.add_to_shader_main("if (VOLUME_RENDERING) {")
         self.add_to_shader_main(volume_rendering_code, indent=2)

--- a/cryoet_data_portal_neuroglancer/models/shader_builder.py
+++ b/cryoet_data_portal_neuroglancer/models/shader_builder.py
@@ -93,7 +93,11 @@ class ImageVolumeShaderBuilder(ShaderBuilder):
 
     def _make_default_shader(self):
         self.add_to_shader_controls(
-            self.make_invertible_invlerp_component(self._contrast_name, self._contrast_limits, self._window_limits),
+            self.make_invertible_invlerp_component(
+                self._contrast_name,
+                self._contrast_limits,
+                self._window_limits,
+            ),
         )
         self.add_to_shader_controls(
             self.make_invertible_invlerp_component(

--- a/cryoet_data_portal_neuroglancer/models/shader_builder.py
+++ b/cryoet_data_portal_neuroglancer/models/shader_builder.py
@@ -19,6 +19,7 @@ class ShaderBuilder:
         else:
             self._shader_pre_main += "\n".join(code)
         self._shader_pre_main += "\n"
+        return self
 
     def add_to_shader_main(self, code: str | list[str], indent: int = 1):
         if isinstance(code, str):
@@ -26,6 +27,7 @@ class ShaderBuilder:
         else:
             self._shader_main_function += "\n".join([TAB * indent + line for line in code])
         self._shader_main_function += "\n"
+        return self
 
     def _make_main(self) -> str:
         return f"void main() {{\n{self._shader_main_function}}}"

--- a/cryoet_data_portal_neuroglancer/models/shader_builder.py
+++ b/cryoet_data_portal_neuroglancer/models/shader_builder.py
@@ -101,7 +101,11 @@ class ImageVolumeShaderBuilder(ShaderBuilder):
         )
         self.add_to_shader_main("emitGrayscale(outputValue);")
 
-    def _add_cross_section_and_vr_code(self, volume_rendering_code: list[str], cross_section_code: list[str]):
+    def _add_cross_section_and_vr_code(
+        self,
+        volume_rendering_code: list[str],
+        cross_section_code: list[str],
+    ):
         self.add_to_shader_main("if (VOLUME_RENDERING) {")
         self.add_to_shader_main(volume_rendering_code, indent=2)
         self.add_to_shader_main("} else {")

--- a/cryoet_data_portal_neuroglancer/models/shader_builder.py
+++ b/cryoet_data_portal_neuroglancer/models/shader_builder.py
@@ -1,0 +1,109 @@
+"""Create GLSL shaders for Neuroglancer."""
+
+from typing import Optional
+
+from cryoet_data_portal_neuroglancer.utils import get_window_limits_from_contrast_limits
+
+TAB = "  "
+
+
+class ShaderBuilder:
+    def __init__(self):
+        self._shader_pre_main = ""
+        self._shader_main_function = ""
+
+    def add_to_shader_controls(self, code: str | list[str]):
+        if isinstance(code, str):
+            self._shader_pre_main += code
+        else:
+            self._shader_pre_main += "\n".join(code)
+        self._shader_pre_main += "\n"
+
+    def add_to_shader_main(self, code: str | list[str], indent: int = 1):
+        if isinstance(code, str):
+            self._shader_main_function += TAB * indent + code
+        else:
+            self._shader_main_function += "\n".join([TAB * indent + line for line in code])
+        self._shader_main_function += "\n"
+
+    def _make_main(self) -> str:
+        return f"void main() {{\n{self._shader_main_function}}}"
+
+    def make_shader(self) -> str:
+        return self._shader_pre_main + "\n" + self._make_main()
+
+    @staticmethod
+    def make_invlerp_component(
+        name: str,
+        contrast_limits: tuple[float, float],
+        window_limits: tuple[float, float],
+    ) -> str:
+        return f"#uicontrol invlerp {name}(range=[{contrast_limits[0]}, {contrast_limits[1]}], window=[{window_limits[0]}, {window_limits[1]}])"
+
+    @staticmethod
+    def make_invertible_invlerp_component(
+        name: str,
+        contrast_limits: tuple[float, float],
+        window_limits: tuple[float, float],
+    ) -> list[str]:
+        invlerp_component = ShaderBuilder.make_invlerp_component(name, contrast_limits, window_limits)
+        checkbox_part = f"#uicontrol bool invert_{name} checkbox(default=false)"
+        data_value_getter = f"float {name}_get() {{ return invert_{name} ? 1.0 - {name}() : {name}(); }}"
+        return [invlerp_component, checkbox_part, data_value_getter]
+
+
+class ImageVolumeShaderBuilder(ShaderBuilder):
+    def __init__(
+        self,
+        contrast_limits: tuple[float, float],
+        threedee_contrast_limits: tuple[float, float],
+        window_limits: Optional[tuple[float, float]] = None,
+        threedee_window_limits: Optional[tuple[float, float]] = None,
+        contrast_name="contrast",
+        threedee_contrast_name="contrast3D",
+    ):
+        super().__init__()
+        self._contrast_limits = contrast_limits
+        self._window_limits = (
+            window_limits if window_limits is not None else get_window_limits_from_contrast_limits(contrast_limits)
+        )
+        self._threedee_contrast_limits = threedee_contrast_limits
+        self._threedee_window_limits = (
+            threedee_window_limits
+            if threedee_window_limits is not None
+            else get_window_limits_from_contrast_limits(threedee_contrast_limits)
+        )
+        self._contrast_name = contrast_name
+        self._threedee_contrast_name = threedee_contrast_name
+
+        self._make_default_shader()
+
+    def _make_default_shader(self):
+        self.add_to_shader_controls(
+            self.make_invertible_invlerp_component(self._contrast_name, self._contrast_limits, self._window_limits),
+        )
+        self.add_to_shader_controls(
+            self.make_invertible_invlerp_component(
+                self._threedee_contrast_name,
+                self._threedee_contrast_limits,
+                self._threedee_window_limits,
+            ),
+        )
+        self.add_to_shader_main("float outputValue;")
+        self._add_cross_section_and_vr_code(
+            [
+                f"outputValue = {self._threedee_contrast_name}_get();",
+                "emitIntensity(outputValue);",
+            ],
+            [
+                f"outputValue = {self._contrast_name}_get();",
+            ],
+        )
+        self.add_to_shader_main("emitGrayscale(outputValue);")
+
+    def _add_cross_section_and_vr_code(self, volume_rendering_code: list[str], cross_section_code: list[str]):
+        self.add_to_shader_main("if (VOLUME_RENDERING) {")
+        self.add_to_shader_main(volume_rendering_code, indent=2)
+        self.add_to_shader_main("} else {")
+        self.add_to_shader_main(cross_section_code, indent=2)
+        self.add_to_shader_main("}")

--- a/cryoet_data_portal_neuroglancer/models/shader_builder.py
+++ b/cryoet_data_portal_neuroglancer/models/shader_builder.py
@@ -73,7 +73,7 @@ class ShaderBuilder:
         invlerp_component = self.make_invlerp_component(name, contrast_limits, window_limits)
         checkbox_part = f"#uicontrol bool invert_{name} checkbox"
         data_value_getter = [
-            f"float {name}_get()" + " {",
+            f"float get_{name}()" + " {",
             f"{TAB}return invert_{name} ? 1.0 - {name}() : {name}();",
             "}",
         ]
@@ -128,11 +128,11 @@ class ImageShaderBuilder(ShaderBuilder):
         self.add_to_shader_main("float outputValue;")
         self._add_cross_section_and_vr_code(
             [
-                f"outputValue = {self._threedee_contrast_name}_get();",
+                f"outputValue = get_{self._threedee_contrast_name}();",
                 "emitIntensity(outputValue);",
             ],
             [
-                f"outputValue = {self._contrast_name}_get();",
+                f"outputValue = get_{self._contrast_name}();",
             ],
         )
         self.add_to_shader_main("emitGrayscale(outputValue);")

--- a/cryoet_data_portal_neuroglancer/models/shader_builder.py
+++ b/cryoet_data_portal_neuroglancer/models/shader_builder.py
@@ -65,7 +65,7 @@ class ShaderBuilder:
         return f"#uicontrol vec3 {name} color"
 
 
-class ImageVolumeShaderBuilder(ShaderBuilder):
+class ImageShaderBuilder(ShaderBuilder):
     def __init__(
         self,
         contrast_limits: tuple[float, float],

--- a/cryoet_data_portal_neuroglancer/models/shader_builder.py
+++ b/cryoet_data_portal_neuroglancer/models/shader_builder.py
@@ -32,9 +32,24 @@ class ShaderBuilder:
     def _make_main(self) -> str:
         return f"void main() {{\n{self._shader_main_function}}}"
 
+    def _make_pre_main(self) -> str:
+        """Sort the preamble for more visually appealing code"""
+        # Extract all the #uicontrol lines and put them at the top
+        uicontrol_lines = []
+        pre_main_lines = []
+        for line in self._shader_pre_main.split("\n"):
+            if line.startswith("#uicontrol"):
+                uicontrol_lines.append(line)
+            else:
+                pre_main_lines.append(line)
+        # Create a blank line between the uicontrols and the rest of the code
+        if len(pre_main_lines) > 1:
+            pre_main_lines.insert(0, "")
+        return "\n".join(uicontrol_lines + pre_main_lines)
+
     def build_shader(self) -> dict[str, str | dict[str, Any]]:
         return {
-            "shader": self._shader_pre_main + "\n" + self._make_main(),
+            "shader": self._make_pre_main() + "\n" + self._make_main(),
             "shaderControls": self._shader_controls,
         }
 
@@ -56,7 +71,7 @@ class ShaderBuilder:
         window_limits: tuple[float, float],
     ) -> list[str]:
         invlerp_component = self.make_invlerp_component(name, contrast_limits, window_limits)
-        checkbox_part = f"#uicontrol bool invert_{name} checkbox(default=false)"
+        checkbox_part = f"#uicontrol bool invert_{name} checkbox"
         data_value_getter = f"float {name}_get() {{ return invert_{name} ? 1.0 - {name}() : {name}(); }}"
         return [invlerp_component, checkbox_part, data_value_getter]
 

--- a/cryoet_data_portal_neuroglancer/models/shader_builder.py
+++ b/cryoet_data_portal_neuroglancer/models/shader_builder.py
@@ -72,7 +72,6 @@ class ImageVolumeShaderBuilder(ShaderBuilder):
         threedee_contrast_limits: tuple[float, float],
         window_limits: Optional[tuple[float, float]] = None,
         threedee_window_limits: Optional[tuple[float, float]] = None,
-        default_color: str = "#FFFFFF",
         contrast_name="contrast",
         threedee_contrast_name="contrast3D",
     ):
@@ -89,7 +88,6 @@ class ImageVolumeShaderBuilder(ShaderBuilder):
         )
         self._contrast_name = contrast_name
         self._threedee_contrast_name = threedee_contrast_name
-        self._default_color = default_color
 
         self._make_default_shader()
 
@@ -108,7 +106,6 @@ class ImageVolumeShaderBuilder(ShaderBuilder):
                 self._threedee_window_limits,
             ),
         )
-        self.add_to_shader_controls(self.make_color_component("color", self._default_color))
         self.add_to_shader_main("float outputValue;")
         self._add_cross_section_and_vr_code(
             [
@@ -119,7 +116,7 @@ class ImageVolumeShaderBuilder(ShaderBuilder):
                 f"outputValue = {self._contrast_name}_get();",
             ],
         )
-        self.add_to_shader_main("emitRGBA(vec4(outputValue * color, outputValue));")
+        self.add_to_shader_main("emitGrayscale(outputValue);")
 
     def _add_cross_section_and_vr_code(
         self,

--- a/cryoet_data_portal_neuroglancer/precompute/points.py
+++ b/cryoet_data_portal_neuroglancer/precompute/points.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from neuroglancer import AnnotationPropertySpec, CoordinateSpace
 from neuroglancer.write_annotations import AnnotationWriter
@@ -101,7 +101,7 @@ def encode_annotation(
     names_by_id: dict[int, str] = None,
     label_key_mapper: Callable[[dict[str, Any]], int] = lambda x: 0,
     color_mapper: Callable[[dict[str, Any]], tuple[int, int, int]] = lambda x: (255, 255, 255),
-    shard_by_id: tuple[int, int] = (0, 10),
+    shard_by_id: Optional[tuple[int, int]] = (0, 10),
 ) -> None:
     if shard_by_id and len(shard_by_id) < 2:
         shard_by_id = (0, 10)

--- a/cryoet_data_portal_neuroglancer/shaders/image.py
+++ b/cryoet_data_portal_neuroglancer/shaders/image.py
@@ -1,0 +1,69 @@
+from typing import Optional
+
+from cryoet_data_portal_neuroglancer.shaders.shader_builder import ShaderBuilder
+from cryoet_data_portal_neuroglancer.utils import get_window_limits_from_contrast_limits
+
+
+class ImageShaderBuilder(ShaderBuilder):
+    def __init__(
+        self,
+        contrast_limits: tuple[float, float],
+        threedee_contrast_limits: tuple[float, float],
+        window_limits: Optional[tuple[float, float]] = None,
+        threedee_window_limits: Optional[tuple[float, float]] = None,
+        contrast_name="contrast",
+        threedee_contrast_name="contrast3D",
+    ):
+        super().__init__()
+        self._contrast_limits = contrast_limits
+        self._window_limits = (
+            window_limits if window_limits is not None else get_window_limits_from_contrast_limits(contrast_limits)
+        )
+        self._threedee_contrast_limits = threedee_contrast_limits
+        self._threedee_window_limits = (
+            threedee_window_limits
+            if threedee_window_limits is not None
+            else get_window_limits_from_contrast_limits(threedee_contrast_limits)
+        )
+        self._contrast_name = contrast_name
+        self._threedee_contrast_name = threedee_contrast_name
+
+        self._make_default_shader()
+
+    def _make_default_shader(self):
+        self.add_to_shader_controls(
+            self.make_invertible_invlerp_component(
+                self._contrast_name,
+                self._contrast_limits,
+                self._window_limits,
+            ),
+        )
+        self.add_to_shader_controls(
+            self.make_invertible_invlerp_component(
+                self._threedee_contrast_name,
+                self._threedee_contrast_limits,
+                self._threedee_window_limits,
+            ),
+        )
+        self.add_to_shader_main("float outputValue;")
+        self._add_cross_section_and_vr_code(
+            [
+                f"outputValue = get_{self._threedee_contrast_name}();",
+                "emitIntensity(outputValue);",
+            ],
+            [
+                f"outputValue = get_{self._contrast_name}();",
+            ],
+        )
+        self.add_to_shader_main("emitGrayscale(outputValue);")
+
+    def _add_cross_section_and_vr_code(
+        self,
+        volume_rendering_code: str | list[str],
+        cross_section_code: str | list[str],
+    ):
+        self.add_to_shader_main("if (VOLUME_RENDERING) {")
+        self.add_to_shader_main(volume_rendering_code, indent=2)
+        self.add_to_shader_main("} else {")
+        self.add_to_shader_main(cross_section_code, indent=2)
+        self.add_to_shader_main("}")

--- a/cryoet_data_portal_neuroglancer/shaders/image.py
+++ b/cryoet_data_portal_neuroglancer/shaders/image.py
@@ -99,14 +99,12 @@ class ImageWithVolumeRenderingShaderBuilder(ImageShaderBuilder):
         threedee_contrast_name : str, optional
             The name of the contrast control for volume rendering, by default "contrast3D".
         """
-        self._suppress_make_shader = True
         super().__init__(
             contrast_limits=contrast_limits,
             window_limits=window_limits,
             contrast_name=contrast_name,
             create_default_shader=False,
         )
-        self._suppress_make_shader = False
         self._threedee_contrast_limits = threedee_contrast_limits
         self._threedee_window_limits = (
             threedee_window_limits

--- a/cryoet_data_portal_neuroglancer/shaders/image.py
+++ b/cryoet_data_portal_neuroglancer/shaders/image.py
@@ -5,32 +5,49 @@ from cryoet_data_portal_neuroglancer.utils import get_window_limits_from_contras
 
 
 class ImageShaderBuilder(ShaderBuilder):
+    """Create a shader for Neuroglancer to display an image.
+
+    The shader will have a contrast control that can be adjusted by the user.
+    The contrast control is invertible.
+    There is no separate volume rendering control for contrast.
+    """
+
     def __init__(
         self,
         contrast_limits: tuple[float, float],
-        threedee_contrast_limits: tuple[float, float],
         window_limits: Optional[tuple[float, float]] = None,
-        threedee_window_limits: Optional[tuple[float, float]] = None,
         contrast_name="contrast",
-        threedee_contrast_name="contrast3D",
+        create_default_shader=True,
     ):
+        """Create a shader for Neuroglancer to display an image.
+
+        Parameters
+        ----------
+        contrast_limits : tuple[float, float]
+            The minimum and maximum values for the contrast control.
+        window_limits : tuple[float, float], optional
+            The minimum and maximum values for the window control, by default None.
+            If None, the window limits will be calculated from the contrast limits.
+        contrast_name : str, optional
+            The name of the contrast control, by default "contrast".
+        create_default_shader : bool, optional
+            Whether to create the default shader, by default True.
+            This is primarily turned off by subclasses.
+            A subclass will call the _make_default_shader method to create the shader.
+            But when initializing the base class, the default shader is usually intended to be created.
+        """
         super().__init__()
         self._contrast_limits = contrast_limits
         self._window_limits = (
             window_limits if window_limits is not None else get_window_limits_from_contrast_limits(contrast_limits)
         )
-        self._threedee_contrast_limits = threedee_contrast_limits
-        self._threedee_window_limits = (
-            threedee_window_limits
-            if threedee_window_limits is not None
-            else get_window_limits_from_contrast_limits(threedee_contrast_limits)
-        )
         self._contrast_name = contrast_name
-        self._threedee_contrast_name = threedee_contrast_name
 
-        self._make_default_shader()
+        # This is a hack to suppress the call to _make_default_shader in the super class
+        if create_default_shader:
+            self._make_default_shader()
 
-    def _make_default_shader(self):
+    def _make_default_shader(self, suppress_emission=False):
         self.add_to_shader_controls(
             self.make_invertible_invlerp_component(
                 self._contrast_name,
@@ -38,6 +55,70 @@ class ImageShaderBuilder(ShaderBuilder):
                 self._window_limits,
             ),
         )
+        self.add_to_shader_main("float outputValue;")
+
+        if not suppress_emission:
+            self.add_to_shader_main(f"outputValue = get_{self._contrast_name}();")
+            self.add_to_shader_main("emitGrayscale(outputValue);")
+
+
+class ImageWithVolumeRenderingShaderBuilder(ImageShaderBuilder):
+    """Create a shader for Neuroglancer to display an image.
+
+    The shader will have a contrast control that can be adjusted by the user.
+    The contrast control is invertible.
+    There is a separate volume rendering control for contrast.
+
+    """
+
+    def __init__(
+        self,
+        contrast_limits: tuple[float, float],
+        threedee_contrast_limits: tuple[float, float],
+        contrast_name="contrast",
+        window_limits: Optional[tuple[float, float]] = None,
+        threedee_window_limits: Optional[tuple[float, float]] = None,
+        threedee_contrast_name="contrast3D",
+    ):
+        """Create a shader for Neuroglancer to display an image.
+
+        Parameters
+        ----------
+        contrast_limits : tuple[float, float]
+            The minimum and maximum values for the contrast control.
+        threedee_contrast_limits : tuple[float, float]
+            The minimum and maximum values for the contrast control for volume rendering.
+        contrast_name : str, optional
+            The name of the contrast control, by default "contrast".
+        window_limits : tuple[float, float], optional
+            The minimum and maximum values for the window control, by default None.
+            If None, the window limits will be calculated from the contrast limits.
+        threedee_window_limits : tuple[float, float], optional
+            The minimum and maximum values for the window control for volume rendering, by default None.
+            If None, the window limits will be calculated from the contrast limits.
+        threedee_contrast_name : str, optional
+            The name of the contrast control for volume rendering, by default "contrast3D".
+        """
+        self._suppress_make_shader = True
+        super().__init__(
+            contrast_limits=contrast_limits,
+            window_limits=window_limits,
+            contrast_name=contrast_name,
+            create_default_shader=False,
+        )
+        self._suppress_make_shader = False
+        self._threedee_contrast_limits = threedee_contrast_limits
+        self._threedee_window_limits = (
+            threedee_window_limits
+            if threedee_window_limits is not None
+            else get_window_limits_from_contrast_limits(threedee_contrast_limits)
+        )
+        self._threedee_contrast_name = threedee_contrast_name
+
+        self._make_default_shader()
+
+    def _make_default_shader(self):
+        super()._make_default_shader(suppress_emission=True)
         self.add_to_shader_controls(
             self.make_invertible_invlerp_component(
                 self._threedee_contrast_name,
@@ -45,7 +126,7 @@ class ImageShaderBuilder(ShaderBuilder):
                 self._threedee_window_limits,
             ),
         )
-        self.add_to_shader_main("float outputValue;")
+
         self._add_cross_section_and_vr_code(
             [
                 f"outputValue = get_{self._threedee_contrast_name}();",
@@ -55,6 +136,7 @@ class ImageShaderBuilder(ShaderBuilder):
                 f"outputValue = get_{self._contrast_name}();",
             ],
         )
+
         self.add_to_shader_main("emitGrayscale(outputValue);")
 
     def _add_cross_section_and_vr_code(

--- a/cryoet_data_portal_neuroglancer/shaders/shader_builder.py
+++ b/cryoet_data_portal_neuroglancer/shaders/shader_builder.py
@@ -1,8 +1,6 @@
 """Create GLSL shaders for Neuroglancer."""
 
-from typing import Any, Optional
-
-from cryoet_data_portal_neuroglancer.utils import get_window_limits_from_contrast_limits
+from typing import Any
 
 TAB = "  "
 
@@ -82,68 +80,3 @@ class ShaderBuilder:
     def make_color_component(self, name: str, default_color: str) -> str:
         self._shader_controls[name] = default_color
         return f"#uicontrol vec3 {name} color"
-
-
-class ImageShaderBuilder(ShaderBuilder):
-    def __init__(
-        self,
-        contrast_limits: tuple[float, float],
-        threedee_contrast_limits: tuple[float, float],
-        window_limits: Optional[tuple[float, float]] = None,
-        threedee_window_limits: Optional[tuple[float, float]] = None,
-        contrast_name="contrast",
-        threedee_contrast_name="contrast3D",
-    ):
-        super().__init__()
-        self._contrast_limits = contrast_limits
-        self._window_limits = (
-            window_limits if window_limits is not None else get_window_limits_from_contrast_limits(contrast_limits)
-        )
-        self._threedee_contrast_limits = threedee_contrast_limits
-        self._threedee_window_limits = (
-            threedee_window_limits
-            if threedee_window_limits is not None
-            else get_window_limits_from_contrast_limits(threedee_contrast_limits)
-        )
-        self._contrast_name = contrast_name
-        self._threedee_contrast_name = threedee_contrast_name
-
-        self._make_default_shader()
-
-    def _make_default_shader(self):
-        self.add_to_shader_controls(
-            self.make_invertible_invlerp_component(
-                self._contrast_name,
-                self._contrast_limits,
-                self._window_limits,
-            ),
-        )
-        self.add_to_shader_controls(
-            self.make_invertible_invlerp_component(
-                self._threedee_contrast_name,
-                self._threedee_contrast_limits,
-                self._threedee_window_limits,
-            ),
-        )
-        self.add_to_shader_main("float outputValue;")
-        self._add_cross_section_and_vr_code(
-            [
-                f"outputValue = get_{self._threedee_contrast_name}();",
-                "emitIntensity(outputValue);",
-            ],
-            [
-                f"outputValue = get_{self._contrast_name}();",
-            ],
-        )
-        self.add_to_shader_main("emitGrayscale(outputValue);")
-
-    def _add_cross_section_and_vr_code(
-        self,
-        volume_rendering_code: str | list[str],
-        cross_section_code: str | list[str],
-    ):
-        self.add_to_shader_main("if (VOLUME_RENDERING) {")
-        self.add_to_shader_main(volume_rendering_code, indent=2)
-        self.add_to_shader_main("} else {")
-        self.add_to_shader_main(cross_section_code, indent=2)
-        self.add_to_shader_main("}")

--- a/cryoet_data_portal_neuroglancer/shaders/shader_builder.py
+++ b/cryoet_data_portal_neuroglancer/shaders/shader_builder.py
@@ -45,7 +45,7 @@ class ShaderBuilder:
             pre_main_lines.insert(0, "")
         return "\n".join(uicontrol_lines + pre_main_lines)
 
-    def build_shader(self) -> dict[str, str | dict[str, Any]]:
+    def build(self) -> dict[str, str | dict[str, Any]]:
         return {
             "shader": self._make_pre_main() + "\n" + self._make_main(),
             "shaderControls": self._shader_controls,

--- a/cryoet_data_portal_neuroglancer/state_generator.py
+++ b/cryoet_data_portal_neuroglancer/state_generator.py
@@ -85,6 +85,7 @@ def generate_image_layer(
     mean: float = None,
     rms: float = None,
     is_visible: bool = True,
+    has_volume_rendering_shader: bool = False,
 ) -> dict[str, Any]:
     source, name, url, _, scale = _setup_creation(source, name, url, scale=scale)
     return ImageJSONGenerator(
@@ -96,6 +97,7 @@ def generate_image_layer(
         mean=mean,
         rms=rms,
         is_visible=is_visible,
+        has_volume_rendering_shader=has_volume_rendering_shader,
     ).to_json()
 
 

--- a/cryoet_data_portal_neuroglancer/state_generator.py
+++ b/cryoet_data_portal_neuroglancer/state_generator.py
@@ -103,14 +103,17 @@ def generate_image_volume_layer(
     source: str,
     name: str = None,
     url: str = None,
+    color: str = "#FFFFFF",
     scale: tuple[float, float, float] = (1.0, 1.0, 1.0),
     is_visible: bool = True,
     rendering_depth: int = 1024,
 ) -> dict[str, Any]:
     source, name, url, _, scale = _setup_creation(source, name, url, scale=scale)
+    _validate_color(color)
     return ImageVolumeJSONGenerator(
         source=source,
         name=name,
+        color=color,
         scale=scale,
         is_visible=is_visible,
         rendering_depth=rendering_depth,

--- a/cryoet_data_portal_neuroglancer/state_generator.py
+++ b/cryoet_data_portal_neuroglancer/state_generator.py
@@ -139,8 +139,6 @@ def combine_json_layers(
         "crossSectionBackgroundColor": "#000000",
         "layout": "4panel",
     }
-    # TODO (skm) the second check can probably be removed once VR
-    # layers have been fully decided upon
     if len(image_layers) > 0 and "_position" in image_layers[0]:
         combined_json["position"] = image_layers[0]["_position"]
         combined_json["crossSectionScale"] = image_layers[0]["_crossSectionScale"]

--- a/cryoet_data_portal_neuroglancer/state_generator.py
+++ b/cryoet_data_portal_neuroglancer/state_generator.py
@@ -106,7 +106,7 @@ def generate_image_volume_layer(
     color: str = "#FFFFFF",
     scale: tuple[float, float, float] = (1.0, 1.0, 1.0),
     is_visible: bool = True,
-    rendering_depth: int = 10000,
+    rendering_depth: int = 1024,
 ) -> dict[str, Any]:
     source, name, url, _, scale = _setup_creation(source, name, url, scale=scale)
     _validate_color(color)

--- a/cryoet_data_portal_neuroglancer/state_generator.py
+++ b/cryoet_data_portal_neuroglancer/state_generator.py
@@ -122,7 +122,7 @@ def generate_image_volume_layer(
 
 def combine_json_layers(
     layers: list[dict[str, Any]],
-    scale: Optional[tuple[float, float, float] | list[float]],
+    scale: tuple[float, float, float] | list[float] | float,
     units: str = "m",
     projection_quaternion: list[float] = None,
 ) -> dict[str, Any]:

--- a/cryoet_data_portal_neuroglancer/state_generator.py
+++ b/cryoet_data_portal_neuroglancer/state_generator.py
@@ -103,17 +103,14 @@ def generate_image_volume_layer(
     source: str,
     name: str = None,
     url: str = None,
-    color: str = "#FFFFFF",
     scale: tuple[float, float, float] = (1.0, 1.0, 1.0),
     is_visible: bool = True,
     rendering_depth: int = 1024,
 ) -> dict[str, Any]:
     source, name, url, _, scale = _setup_creation(source, name, url, scale=scale)
-    _validate_color(color)
     return ImageVolumeJSONGenerator(
         source=source,
         name=name,
-        color=color,
         scale=scale,
         is_visible=is_visible,
         rendering_depth=rendering_depth,

--- a/cryoet_data_portal_neuroglancer/state_generator.py
+++ b/cryoet_data_portal_neuroglancer/state_generator.py
@@ -142,7 +142,9 @@ def combine_json_layers(
         "crossSectionBackgroundColor": "#000000",
         "layout": "4panel",
     }
-    if image_layers is not None:
+    # TODO (skm) the second check can probably be removed once VR
+    # layers have been fully decided upon
+    if len(image_layers) > 0 and "_position" in image_layers[0]:
         combined_json["position"] = image_layers[0]["_position"]
         combined_json["crossSectionScale"] = image_layers[0]["_crossSectionScale"]
         combined_json["projectionScale"] = image_layers[0]["_projectionScale"]

--- a/cryoet_data_portal_neuroglancer/utils.py
+++ b/cryoet_data_portal_neuroglancer/utils.py
@@ -103,7 +103,10 @@ def number_of_encoding_bits(nb_values: int) -> int:
     raise ValueError("Too many unique values in block")
 
 
-def get_window_limits_from_contrast_limits(contrast_limits: tuple[float, float]) -> tuple[float, float]:
+def get_window_limits_from_contrast_limits(
+    contrast_limits: tuple[float, float],
+    distance_scale: float = 0.1,
+) -> tuple[float, float]:
     """
     Create default window limits from contrast limits, 10% padding
 
@@ -123,6 +126,6 @@ def get_window_limits_from_contrast_limits(contrast_limits: tuple[float, float])
         lower_contrast, higher_contrast = higher_contrast, lower_contrast
 
     distance = higher_contrast - lower_contrast
-    window_start = lower_contrast - (distance / 10)
-    window_end = higher_contrast + (distance / 10)
+    window_start = lower_contrast - (distance * distance_scale)
+    window_end = higher_contrast + (distance * distance_scale)
     return window_start, window_end

--- a/cryoet_data_portal_neuroglancer/utils.py
+++ b/cryoet_data_portal_neuroglancer/utils.py
@@ -101,3 +101,27 @@ def number_of_encoding_bits(nb_values: int) -> int:
         if (1 << nb_bits) >= nb_values:
             return nb_bits
     raise ValueError("Too many unique values in block")
+
+
+def get_window_limits_from_contrast_limits(contrast_limits: tuple[float, float]) -> tuple[float, float]:
+    """
+    Create default window limits from contrast limits, 10% padding
+
+    Parameters
+    ----------
+    contrast_limits : tuple[float, float]
+        The contrast limits
+
+    Returns
+    -------
+    tuple[float, float]
+        The window limits
+    """
+    # First check if the contrast limits are inverted
+    if contrast_limits[0] > contrast_limits[1]:
+        contrast_limits = (contrast_limits[1], contrast_limits[0])
+
+    distance = contrast_limits[1] - contrast_limits[0]
+    window_start = contrast_limits[0] - (distance / 10)
+    window_end = contrast_limits[1] + (distance / 10)
+    return window_start, window_end

--- a/cryoet_data_portal_neuroglancer/utils.py
+++ b/cryoet_data_portal_neuroglancer/utils.py
@@ -117,11 +117,12 @@ def get_window_limits_from_contrast_limits(contrast_limits: tuple[float, float])
     tuple[float, float]
         The window limits
     """
+    lower_contrast, higher_contrast = contrast_limits
     # First check if the contrast limits are inverted
-    if contrast_limits[0] > contrast_limits[1]:
-        contrast_limits = (contrast_limits[1], contrast_limits[0])
+    if lower_contrast > higher_contrast:
+        lower_contrast, higher_contrast = higher_contrast, lower_contrast
 
-    distance = contrast_limits[1] - contrast_limits[0]
-    window_start = contrast_limits[0] - (distance / 10)
-    window_end = contrast_limits[1] + (distance / 10)
+    distance = higher_contrast - lower_contrast
+    window_start = lower_contrast - (distance / 10)
+    window_end = higher_contrast + (distance / 10)
     return window_start, window_end

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -41,7 +41,7 @@ void main() {
         contrast_name=contrast_name,
         threedee_contrast_name=threedee_contrast_name,
     )
-    shader = shader_builder.build_shader()
+    shader = shader_builder.build()
     actual_shader = shader["shader"]
     assert actual_shader == expected_shader.strip()
 
@@ -78,7 +78,7 @@ void main() {
         window_limits=window_limits,
         contrast_name=contrast_name,
     )
-    shader = shader_builder.build_shader()
+    shader = shader_builder.build()
     actual_shader = shader["shader"]
     assert actual_shader == expected_shader.strip()
 
@@ -97,7 +97,7 @@ void main() {
 }
 """
     shader_components = (
-        ShaderBuilder().add_to_shader_controls("#uicontrol test").add_to_shader_main("test_main").build_shader()
+        ShaderBuilder().add_to_shader_controls("#uicontrol test").add_to_shader_main("test_main").build()
     )
     assert shader_components["shader"] == expected_shader.strip()
     assert shader_components["shaderControls"] == {}

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -14,8 +14,12 @@ def test_get_default_image_shader():
 #uicontrol invlerp contrast3D
 #uicontrol bool invert_contrast3D checkbox
 
-float contrast_get() { return invert_contrast ? 1.0 - contrast() : contrast(); }
-float contrast3D_get() { return invert_contrast3D ? 1.0 - contrast3D() : contrast3D(); }
+float contrast_get() {
+  return invert_contrast ? 1.0 - contrast() : contrast();
+}
+float contrast3D_get() {
+  return invert_contrast3D ? 1.0 - contrast3D() : contrast3D();
+}
 
 void main() {
   float outputValue;

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -15,6 +15,7 @@ float contrast_get() { return invert_contrast ? 1.0 - contrast() : contrast(); }
 #uicontrol invlerp contrast3D
 #uicontrol bool invert_contrast3D checkbox(default=false)
 float contrast3D_get() { return invert_contrast3D ? 1.0 - contrast3D() : contrast3D(); }
+#uicontrol vec3 color color
 
 void main() {
   float outputValue;
@@ -24,7 +25,7 @@ void main() {
   } else {
     outputValue = contrast_get();
   }
-  emitGrayscale(outputValue);
+  emitRGBA(vec4(outputValue * color, outputValue));
 }
 """
     shader_builder = ImageVolumeShaderBuilder(
@@ -35,7 +36,7 @@ void main() {
         contrast_name=contrast_name,
         threedee_contrast_name=threedee_contrast_name,
     )
-    shader = shader_builder.make_shader()
+    shader = shader_builder.build_shader()
     actual_shader = shader["shader"]
     assert actual_shader.strip() == expected_shader.strip()
 

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -1,4 +1,4 @@
-from cryoet_data_portal_neuroglancer.models.shader_builder import ImageVolumeShaderBuilder, ShaderBuilder
+from cryoet_data_portal_neuroglancer.models.shader_builder import ImageShaderBuilder, ShaderBuilder
 
 
 def test_get_default_image_shader():
@@ -27,7 +27,7 @@ void main() {
   emitGrayscale(outputValue);
 }
 """
-    shader_builder = ImageVolumeShaderBuilder(
+    shader_builder = ImageShaderBuilder(
         contrast_limits=contrast_limits,
         window_limits=window_limits,
         threedee_contrast_limits=threedee_contrast_limits,

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -1,4 +1,5 @@
-from cryoet_data_portal_neuroglancer.models.shader_builder import ImageShaderBuilder, ShaderBuilder
+from cryoet_data_portal_neuroglancer.shaders.image import ImageShaderBuilder
+from cryoet_data_portal_neuroglancer.shaders.shader_builder import ShaderBuilder
 
 
 def test_get_default_image_shader():

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -6,11 +6,13 @@ def test_get_default_image_shader():
     window_limits = (0.0, 1.0)
     threedee_contrast_limits = (1.0, -1.0)
     threedee_window_limits = None
+    contrast_name = "contrast"
+    threedee_contrast_name = "contrast3D"
     expected_shader = """
-#uicontrol invlerp contrast(range=[0.0, 1.0], window=[0.0, 1.0])
+#uicontrol invlerp contrast
 #uicontrol bool invert_contrast checkbox(default=false)
 float contrast_get() { return invert_contrast ? 1.0 - contrast() : contrast(); }
-#uicontrol invlerp contrast3D(range=[1.0, -1.0], window=[-1.2, 1.2])
+#uicontrol invlerp contrast3D
 #uicontrol bool invert_contrast3D checkbox(default=false)
 float contrast3D_get() { return invert_contrast3D ? 1.0 - contrast3D() : contrast3D(); }
 
@@ -30,7 +32,18 @@ void main() {
         window_limits=window_limits,
         threedee_contrast_limits=threedee_contrast_limits,
         threedee_window_limits=threedee_window_limits,
+        contrast_name=contrast_name,
+        threedee_contrast_name=threedee_contrast_name,
     )
-    actual_shader = shader_builder.make_shader()
-    print(actual_shader)
+    shader = shader_builder.make_shader()
+    actual_shader = shader["shader"]
     assert actual_shader.strip() == expected_shader.strip()
+
+    shader_controls = shader["shaderControls"]
+    contrast_control = shader_controls[contrast_name]
+    assert contrast_control["range"] == list(contrast_limits)
+    assert contrast_control["window"] == list(window_limits)
+
+    contrast_threedee_control = shader_controls[threedee_contrast_name]
+    assert contrast_threedee_control["range"] == list(threedee_contrast_limits)
+    assert contrast_threedee_control["window"] == [-1.2, 1.2]

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -1,4 +1,4 @@
-from cryoet_data_portal_neuroglancer.models.shader_builder import ImageVolumeShaderBuilder
+from cryoet_data_portal_neuroglancer.models.shader_builder import ImageVolumeShaderBuilder, ShaderBuilder
 
 
 def test_get_default_image_shader():
@@ -38,7 +38,7 @@ void main() {
     )
     shader = shader_builder.build_shader()
     actual_shader = shader["shader"]
-    assert actual_shader.strip() == expected_shader.strip()
+    assert actual_shader == expected_shader.strip()
 
     shader_controls = shader["shaderControls"]
     contrast_control = shader_controls[contrast_name]
@@ -48,3 +48,18 @@ void main() {
     contrast_threedee_control = shader_controls[threedee_contrast_name]
     assert contrast_threedee_control["range"] == list(threedee_contrast_limits)
     assert contrast_threedee_control["window"] == [-1.2, 1.2]
+
+
+def test_shader_builder():
+    expected_shader = """
+#uicontrol test
+
+void main() {
+  test_main
+}
+"""
+    shader_components = (
+        ShaderBuilder().add_to_shader_controls("#uicontrol test").add_to_shader_main("test_main").build_shader()
+    )
+    assert shader_components["shader"] == expected_shader.strip()
+    assert shader_components["shaderControls"] == {}

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -15,7 +15,6 @@ float contrast_get() { return invert_contrast ? 1.0 - contrast() : contrast(); }
 #uicontrol invlerp contrast3D
 #uicontrol bool invert_contrast3D checkbox(default=false)
 float contrast3D_get() { return invert_contrast3D ? 1.0 - contrast3D() : contrast3D(); }
-#uicontrol vec3 color color
 
 void main() {
   float outputValue;
@@ -25,7 +24,7 @@ void main() {
   } else {
     outputValue = contrast_get();
   }
-  emitRGBA(vec4(outputValue * color, outputValue));
+  emitGrayscale(outputValue);
 }
 """
     shader_builder = ImageVolumeShaderBuilder(

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -1,0 +1,36 @@
+from cryoet_data_portal_neuroglancer.models.shader_builder import ImageVolumeShaderBuilder
+
+
+def test_get_default_image_shader():
+    contrast_limits = (0.0, 1.0)
+    window_limits = (0.0, 1.0)
+    threedee_contrast_limits = (1.0, -1.0)
+    threedee_window_limits = None
+    expected_shader = """
+#uicontrol invlerp contrast(range=[0.0, 1.0], window=[0.0, 1.0])
+#uicontrol bool invert_contrast checkbox(default=false)
+float contrast_get() { return invert_contrast ? 1.0 - contrast() : contrast(); }
+#uicontrol invlerp contrast3D(range=[1.0, -1.0], window=[-1.2, 1.2])
+#uicontrol bool invert_contrast3D checkbox(default=false)
+float contrast3D_get() { return invert_contrast3D ? 1.0 - contrast3D() : contrast3D(); }
+
+void main() {
+  float outputValue;
+  if (VOLUME_RENDERING) {
+    outputValue = contrast3D_get();
+    emitIntensity(outputValue);
+  } else {
+    outputValue = contrast_get();
+  }
+  emitGrayscale(outputValue);
+}
+"""
+    shader_builder = ImageVolumeShaderBuilder(
+        contrast_limits=contrast_limits,
+        window_limits=window_limits,
+        threedee_contrast_limits=threedee_contrast_limits,
+        threedee_window_limits=threedee_window_limits,
+    )
+    actual_shader = shader_builder.make_shader()
+    print(actual_shader)
+    assert actual_shader.strip() == expected_shader.strip()

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -10,10 +10,11 @@ def test_get_default_image_shader():
     threedee_contrast_name = "contrast3D"
     expected_shader = """
 #uicontrol invlerp contrast
-#uicontrol bool invert_contrast checkbox(default=false)
-float contrast_get() { return invert_contrast ? 1.0 - contrast() : contrast(); }
+#uicontrol bool invert_contrast checkbox
 #uicontrol invlerp contrast3D
-#uicontrol bool invert_contrast3D checkbox(default=false)
+#uicontrol bool invert_contrast3D checkbox
+
+float contrast_get() { return invert_contrast ? 1.0 - contrast() : contrast(); }
 float contrast3D_get() { return invert_contrast3D ? 1.0 - contrast3D() : contrast3D(); }
 
 void main() {

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -1,8 +1,8 @@
-from cryoet_data_portal_neuroglancer.shaders.image import ImageShaderBuilder
+from cryoet_data_portal_neuroglancer.shaders.image import ImageShaderBuilder, ImageWithVolumeRenderingShaderBuilder
 from cryoet_data_portal_neuroglancer.shaders.shader_builder import ShaderBuilder
 
 
-def test_get_default_image_shader():
+def test_get_default_image_vr_shader():
     contrast_limits = (0.0, 1.0)
     window_limits = (0.0, 1.0)
     threedee_contrast_limits = (1.0, -1.0)
@@ -33,7 +33,7 @@ void main() {
   emitGrayscale(outputValue);
 }
 """
-    shader_builder = ImageShaderBuilder(
+    shader_builder = ImageWithVolumeRenderingShaderBuilder(
         contrast_limits=contrast_limits,
         window_limits=window_limits,
         threedee_contrast_limits=threedee_contrast_limits,
@@ -53,6 +53,39 @@ void main() {
     contrast_threedee_control = shader_controls[threedee_contrast_name]
     assert contrast_threedee_control["range"] == list(threedee_contrast_limits)
     assert contrast_threedee_control["window"] == [-1.2, 1.2]
+
+
+def test_get_default_image_shader():
+    contrast_limits = (0.0, 1.0)
+    window_limits = (0.0, 1.0)
+    contrast_name = "contrast"
+    expected_shader = """
+#uicontrol invlerp contrast
+#uicontrol bool invert_contrast checkbox
+
+float get_contrast() {
+  return invert_contrast ? 1.0 - contrast() : contrast();
+}
+
+void main() {
+  float outputValue;
+  outputValue = get_contrast();
+  emitGrayscale(outputValue);
+}
+"""
+    shader_builder = ImageShaderBuilder(
+        contrast_limits=contrast_limits,
+        window_limits=window_limits,
+        contrast_name=contrast_name,
+    )
+    shader = shader_builder.build_shader()
+    actual_shader = shader["shader"]
+    assert actual_shader == expected_shader.strip()
+
+    shader_controls = shader["shaderControls"]
+    contrast_control = shader_controls[contrast_name]
+    assert contrast_control["range"] == list(contrast_limits)
+    assert contrast_control["window"] == list(window_limits)
 
 
 def test_shader_builder():

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -14,20 +14,20 @@ def test_get_default_image_shader():
 #uicontrol invlerp contrast3D
 #uicontrol bool invert_contrast3D checkbox
 
-float contrast_get() {
+float get_contrast() {
   return invert_contrast ? 1.0 - contrast() : contrast();
 }
-float contrast3D_get() {
+float get_contrast3D() {
   return invert_contrast3D ? 1.0 - contrast3D() : contrast3D();
 }
 
 void main() {
   float outputValue;
   if (VOLUME_RENDERING) {
-    outputValue = contrast3D_get();
+    outputValue = get_contrast3D();
     emitIntensity(outputValue);
   } else {
-    outputValue = contrast_get();
+    outputValue = get_contrast();
   }
   emitGrayscale(outputValue);
 }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,6 +53,8 @@ def test__get_grid_size_from_block_shape(dshape, bshape, expected):
         ((100, -100), (-120, 120)),
     ],
 )
-def test_create_default_window_limits_from_contrast_limits(contrast_limits, window_limits):
+def test_create_default_window_limits_from_contrast_limits(
+    contrast_limits,
+    window_limits,
+):
     assert get_window_limits_from_contrast_limits(contrast_limits) == window_limits
-    assert contrast_limits == contrast_limits

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import pytest
 
 from cryoet_data_portal_neuroglancer.utils import (
     get_grid_size_from_block_shape,
+    get_window_limits_from_contrast_limits,
     number_of_encoding_bits,
 )
 
@@ -41,3 +42,17 @@ def test___number_of_encoding_bits__too_many_values():
 )
 def test__get_grid_size_from_block_shape(dshape, bshape, expected):
     assert get_grid_size_from_block_shape(dshape, bshape) == expected
+
+
+@pytest.mark.parametrize(
+    "contrast_limits, window_limits",
+    [
+        ((0.0, 1.0), (-0.1, 1.1)),
+        ((-5.0, 5.0), (-6.0, 6.0)),
+        ((20, 10), (9, 21)),
+        ((100, -100), (-120, 120)),
+    ],
+)
+def test_create_default_window_limits_from_contrast_limits(contrast_limits, window_limits):
+    assert get_window_limits_from_contrast_limits(contrast_limits) == window_limits
+    assert contrast_limits == contrast_limits


### PR DESCRIPTION
Adds a shader builder to create a GLSL shader with separate invertible contrast limits for both 2D cross sections, and 3D volume rendering.

If we agree on the builder class structure, we could look to refactor the other shaders which are defined inline in `json_generator.py` into the builder class and add tests for those shaders too.

Also refactors a little bit to support adding this a bit easier and a few associated fixes.

The final shader would be like this:
```
#uicontrol invlerp contrast
#uicontrol bool invert_contrast checkbox
#uicontrol invlerp contrast3D
#uicontrol bool invert_contrast3D checkbox

float get_contrast() {
  return invert_contrast ? 1.0 - contrast() : contrast();
}
float get_contrast3D() {
  return invert_contrast3D ? 1.0 - contrast3D() : contrast3D();
}

void main() {
  float outputValue;
  if (VOLUME_RENDERING) {
    outputValue = get_contrast3D();
    emitIntensity(outputValue);
  } else {
    outputValue = get_contrast();
  }
  emitGrayscale(outputValue);
}
```


With the values for the contrast limits and window limits stored in the JSON state as the layer shader controls parameter