### PR TITLE
Setting point name type by number of values

### DIFF
--- a/cryoet_data_portal_neuroglancer/precompute/points.py
+++ b/cryoet_data_portal_neuroglancer/precompute/points.py
@@ -32,7 +32,7 @@ def _write_annotations(
         properties=[
             AnnotationPropertySpec(
                 id="name",
-                type="uint8",
+                type="uint8" if len(names_by_id) < 2**8 else "uint16",
                 enum_values=list(names_by_id.keys()),
                 enum_labels=list(names_by_id.values()),
             ),


### PR DESCRIPTION
## Changes Introduced

In some cases, there are more than 256 distinct labels, for instance-segmentation points, so setting the type to be `uint16` for those cases. 
