### PR TITLE
style: rename oriented point JSON generator

### DIFF
--- a/cryoet_data_portal_neuroglancer/models/json_generator.py
+++ b/cryoet_data_portal_neuroglancer/models/json_generator.py
@@ -167,7 +167,7 @@ class AnnotationJSONGenerator(RenderingJSONGenerator):
 
 
 @dataclass
-class OrientedPointAnnotationGenerator(AnnotationJSONGenerator):
+class OrientedPointAnnotationJSONGenerator(AnnotationJSONGenerator):
     """Generates JSON Neuroglancer config for oriented point annotation."""
 
     line_width: float = 1.0

--- a/cryoet_data_portal_neuroglancer/state_generator.py
+++ b/cryoet_data_portal_neuroglancer/state_generator.py
@@ -8,7 +8,7 @@ from cryoet_data_portal_neuroglancer.models.json_generator import (
     AnnotationJSONGenerator,
     ImageJSONGenerator,
     ImageVolumeJSONGenerator,
-    OrientedPointAnnotationGenerator,
+    OrientedPointAnnotationJSONGenerator,
     SegmentationJSONGenerator,
 )
 from cryoet_data_portal_neuroglancer.utils import get_scale
@@ -70,7 +70,7 @@ def generate_oriented_point_layer(
 ) -> dict[str, Any]:
     source, name, url, _, scale = _setup_creation(source, name, url, scale=scale)
     _validate_color(color)
-    return OrientedPointAnnotationGenerator(
+    return OrientedPointAnnotationJSONGenerator(
         source=source,
         name=name,
         color=color,


### PR DESCRIPTION
No fix seems to be required, though clarified the role of the annotation generator with more consistent naming