### PR TITLE
feat: update default layout of the main neuroglancer landing page

### DIFF
--- a/cryoet_data_portal_neuroglancer/state_generator.py
+++ b/cryoet_data_portal_neuroglancer/state_generator.py
@@ -269,11 +269,16 @@ def combine_json_layers(
         "selectedLayer": {
             "visible": True,
             "layer": layers[0]["name"],
+            "side": "left",
         },
         "crossSectionBackgroundColor": "#000000",
         "layout": "4panel",
         "showSlices": set_slices_visible_in_3d,
         "showAxisLines": show_axis_lines,
+        "layerListPanel": {
+            "row": 1,
+            "visible": True,
+        },
     }
     if len(image_layers) > 0 and "_position" in image_layers[0]:
         combined_json["position"] = image_layers[0]["_position"]

--- a/cryoet_data_portal_neuroglancer/state_generator.py
+++ b/cryoet_data_portal_neuroglancer/state_generator.py
@@ -279,6 +279,18 @@ def combine_json_layers(
             "row": 1,
             "visible": True,
         },
+        "helpPanel": {
+            "side": "right",
+            "row": 0,
+        },
+        "settingsPanel": {
+            "side": "right",
+            "row": 1,
+        },
+        "selection": {
+            "row": 2,
+            "visible": False,
+        },
     }
     if len(image_layers) > 0 and "_position" in image_layers[0]:
         combined_json["position"] = image_layers[0]["_position"]


### PR DESCRIPTION
Layout would change to be, controls top left, and layer list bottom left

![image](https://github.com/user-attachments/assets/03f6a3b6-7251-456c-ac10-7a7c3e68b53c)

And the other panels, if opened, appear on the right

![image](https://github.com/user-attachments/assets/dfb44a27-8bb7-465a-a7eb-2e8d56fe6c18)

The state also supports a "flex" option for these panels on looking into it. This is used by specifying for both the panel that is getting bigger, by how much, and for the smaller one, by how much. For example, `flex:1.2` and `flex:0.8` for the controls panel and layer list panel respectively, as they are in the same column. Using the flex parameter, further fine-tuning is possible.