### PR TITLE
fix: Update runs-on labels in GitHub Actions workflows

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -14,6 +14,6 @@ concurrency:
   cancel-in-progress: true
 jobs:
   conventional_commit_title:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@v1.5.0


### PR DESCRIPTION
https://czi.atlassian.net/browse/CCIE-3911

This PR updates 'runs-on' in GitHub Actions workflow files to use direct values instead of label arrays.