### PR TITLE
Feature: allow new panel type as optional param

### DIFF
--- a/cryoet_data_portal_neuroglancer/state_generator.py
+++ b/cryoet_data_portal_neuroglancer/state_generator.py
@@ -256,6 +256,7 @@ def combine_json_layers(
     projection_quaternion: list[float] | None = None,
     set_slices_visible_in_3d: bool | None = None,
     show_axis_lines: bool = True,
+    use_old_neuroglancer_layout: bool = True,
 ) -> dict[str, Any]:
     """Note, if set_slices_visible_in_3d is not provided, it will be set to False if there are any image layers in the list with volume rendering."""
     image_layers = [layer for layer in layers if layer["type"] == "image"]
@@ -265,6 +266,8 @@ def combine_json_layers(
     scale = get_scale(scale)
     if projection_quaternion is None:
         projection_quaternion = Rotation.from_euler(seq="xyz", angles=(45, 0, 0), degrees=True).as_quat()
+
+    layout = "4panel" if use_old_neuroglancer_layout else "4panel-alt"
     combined_json = {
         "dimensions": {dim: [res, units] for dim, res in zip("xyz", scale, strict=False)},
         "crossSectionScale": 1.8,
@@ -277,7 +280,7 @@ def combine_json_layers(
         },
         "crossSectionBackgroundColor": "#000000",
         "hideCrossSectionBackgroundIn3D": True,
-        "layout": "4panel",
+        "layout": layout,
         "showSlices": set_slices_visible_in_3d,
         "showAxisLines": show_axis_lines,
         "layerListPanel": {

--- a/tests/test_state_generators.py
+++ b/tests/test_state_generators.py
@@ -45,7 +45,7 @@ def np_is_close(array1, array2):
     return np.isclose(np.array(array1), np.array(array2)).all()
 
 
-def test__combine_json_layers():
+def test__combine_json_layers_default_values():
     image_json = generate_image_layer(
         source="mysource",
         scale=[1.5, 0.5, 2.5],

--- a/tests/test_state_generators.py
+++ b/tests/test_state_generators.py
@@ -1,4 +1,7 @@
+import numpy as np
+
 from cryoet_data_portal_neuroglancer.state_generator import (
+    combine_json_layers,
     generate_image_layer,
     generate_oriented_point_layer,
     generate_point_layer,
@@ -35,3 +38,33 @@ def test__generate_point_layer_default_values():
 
     assert "codeVisible" in state
     assert state["codeVisible"] is False
+
+
+def np_is_close(array1, array2):
+    """Helper function for list of float comparison."""
+    return np.isclose(np.array(array1), np.array(array2)).all()
+
+
+def test__combine_json_layers():
+    image_json = generate_image_layer(
+        source="mysource",
+        scale=[1.5, 0.5, 2.5],
+        size={"x": 400, "y": 200, "z": 150},
+        start={"x": 100, "y": 50, "z": 25},
+    )
+    combined_json = combine_json_layers(layers=[image_json], scale=[1.0, 1.2, 0.1])
+
+    expected_dimensions = {"x": [1.0, "m"], "y": [1.2, "m"], "z": [0.1, "m"]}
+    expected_projection_orientation = [0.3826834, 0, 0, 0.9238796]
+    expected_position = [250.0, 125.0, 88.0]
+
+    # Assertions
+    assert combined_json["layers"][0] == image_json
+    assert combined_json["dimensions"] == expected_dimensions
+    assert np_is_close(
+        combined_json["projectionOrientation"],
+        expected_projection_orientation,
+    )
+    assert combined_json["layout"] == "4panel"
+    assert combined_json["showSlices"]
+    assert np_is_close(combined_json["position"], expected_position)


### PR DESCRIPTION
The default is the previous "4panel" but "4panel-alt" is supported. 

I also added a test for some of the more complicated parts of the JSON state combiner. It doesn't cover everything right now as I didn't want to blow this small change completely out of proportion - but wanted to make sure the a default param call to this function would give the expected result.

Would close #38 