### PR TITLE
fix: rename hide cross section to correct name

### DIFF
--- a/cryoet_data_portal_neuroglancer/state_generator.py
+++ b/cryoet_data_portal_neuroglancer/state_generator.py
@@ -280,7 +280,7 @@ def combine_json_layers(
             "side": "left",
         },
         "crossSectionBackgroundColor": "#000000",
-        "hideCrossSectionBackgroundIn3D": True,
+        "hideCrossSectionBackground3D": True,
         "layout": layout,
         "showSlices": set_slices_visible_in_3d,
         "showAxisLines": show_axis_lines,


### PR DESCRIPTION
During the PR to neuroglancer, the name of this setting changed, so this is to fix that