### PR TITLE
fix: manually mark locations for release please to update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cryoet-data-portal-neuroglancer"
-version = "1.2.1" # {x-release-please-version}
+version = "1.2.1" # x-release-please-version
 description = "Utility package for working with Neuroglancer data in the CZI Cryo-ET Data Portal"
 authors = [
     {name="CZI Imaging Team",  email="cryoetdataportal@chanzuckerberg.com"},
@@ -27,7 +27,7 @@ repository = "https://github.com/chanzuckerberg/cryoet-data-portal-neuroglancer"
 
 [tool.poetry]
 name = "cryoet-data-portal-neuroglancer"
-version = "1.1.0" # {x-release-please-version}
+version = "1.1.0" # x-release-please-version
 description = "Utility package for working with Neuroglancer data in the CZI Cryo-ET Data Portal"
 authors = [
     "CZI Imaging Team <cryoetdataportal@chanzuckerberg.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cryoet-data-portal-neuroglancer"
-version = "1.2.1"
+version = "1.2.1" # {x-release-please-version}
 description = "Utility package for working with Neuroglancer data in the CZI Cryo-ET Data Portal"
 authors = [
     {name="CZI Imaging Team",  email="cryoetdataportal@chanzuckerberg.com"},
@@ -27,7 +27,7 @@ repository = "https://github.com/chanzuckerberg/cryoet-data-portal-neuroglancer"
 
 [tool.poetry]
 name = "cryoet-data-portal-neuroglancer"
-version = "1.1.0"
+version = "1.1.0" # {x-release-please-version}
 description = "Utility package for working with Neuroglancer data in the CZI Cryo-ET Data Portal"
 authors = [
     "CZI Imaging Team <cryoetdataportal@chanzuckerberg.com>",


### PR DESCRIPTION
This should fix #43, see https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files

It's a little unclear to me if the `{}` are needed around the instruction or not though -- but I think it is the right direction.