### PR TITLE
chore: change release please to use generic updater

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,13 @@
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
-      "release-type": "python"
+      "release-type": "python",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "path/to/file.yml"
+        }
+      ]
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,7 +20,7 @@
       "extra-files": [
         {
           "type": "generic",
-          "path": "path/to/file.yml"
+          "path": "pyproject.toml"
         }
       ]
     }


### PR DESCRIPTION
The python updater will only update either the project OR the poetry.tool because both are not intended to be used.
See https://github.com/googleapis/release-please/blob/main/src/updaters/python/pyproject-toml.ts.

Later, I think it better to possibly change this, but need to understand better why #31 introduced both versions before doing that