### PR TITLE
feat: allow control over empty seg blocks

### DIFF
--- a/cryoet_data_portal_neuroglancer/precompute/mesh.py
+++ b/cryoet_data_portal_neuroglancer/precompute/mesh.py
@@ -666,6 +666,7 @@ def generate_multiresolution_mesh_from_segmentation(
     min_mesh_chunk_dim: int = 16,
     max_simplification_error: int = 10,
     labels_dict: dict[int, str] | None = None,
+    fill_missing: bool = False,
 ) -> None:
     """Generates the meshes for a segmentation stored as a precomputed Neuroglancer format.
 
@@ -689,6 +690,10 @@ def generate_multiresolution_mesh_from_segmentation(
     labels_dict: dict[int, str] | None
         A dictionary of labels to string labels. This is used to generate the segment properties
         for the segmentation. If None, no segment properties are generated.
+    fill_missing: bool
+        Fills in empty volumes with a volume filled with the label 0.
+        By default, this is False. But can be set to True if the mesh bounds
+        are determined via fast bounding box calculation.
     """
     tq = LocalTaskQueue()
 
@@ -702,7 +707,7 @@ def generate_multiresolution_mesh_from_segmentation(
         shape=(256, 256, 256),
         mesh_dir=mesh_directory,
         sharded=True,
-        fill_missing=False,
+        fill_missing=fill_missing,
         max_simplification_error=max_simplification_error,
         simplification=simplification,
     )

--- a/cryoet_data_portal_neuroglancer/precompute/segmentation_mask.py
+++ b/cryoet_data_portal_neuroglancer/precompute/segmentation_mask.py
@@ -312,6 +312,7 @@ def encode_segmentation(
     fast_bounding_box: bool = False,
     max_simplification_error_in_voxels: int = 2,
     labels_dict: dict[int, str] | None = None,
+    fill_missing: bool = False,
 ) -> None:
     """Convert the given OME-Zarr file to neuroglancer segmentation format with the given block size
 
@@ -373,6 +374,11 @@ def encode_segmentation(
         A dictionary mapping the integer labels in the segmentation to
         human-readable names, by default None
         This is useful for generating a legend in the viewer
+    fill_missing : bool, optional
+        Although the fast bounding box is not recommended for segmentations
+        with large empty regions, sometimes you may want to use it anyway.
+        In this case, you can set this parameter to True to fill the
+        missing regions with the value of the background (label 0).
     """
     LOGGER.info("Converting %s to neuroglancer compressed segmentation format", filename)
     output_path = Path(output_path)
@@ -430,6 +436,7 @@ def encode_segmentation(
             mesh_shape=mesh_shape,
             min_mesh_chunk_dim=min_mesh_chunk_dim,
             max_simplification_error=max_simplification_error,
+            fill_missing=fill_missing,
         )
         clean_mesh_folder(output_path, mesh_directory)
 


### PR DESCRIPTION
Cloudvolume errors on empty volumes by default. For us, this is usually good, but in some cases you might want to override it -- This allows that