### PR TITLE
feat: allow colors to be dict of seg label to color str in seg mask gen

### DIFF
--- a/cryoet_data_portal_neuroglancer/models/json_generator.py
+++ b/cryoet_data_portal_neuroglancer/models/json_generator.py
@@ -243,7 +243,7 @@ class OrientedPointAnnotationJSONGenerator(AnnotationJSONGenerator):
 class SegmentationJSONGenerator(RenderingJSONGenerator):
     """Generates JSON Neuroglancer config for segmentation mask."""
 
-    color: str | None = None
+    color: str | dict[int, str] | None = None
     is_visible: bool = True
     display_mesh: bool = True
     display_bounding_box: bool = False
@@ -276,10 +276,12 @@ class SegmentationJSONGenerator(RenderingJSONGenerator):
             "meshRenderScale": self.mesh_render_scale,
             "pick": self.enable_pick,
         }
-        # self.color === None means that the color will be random
-        # This is useful for multiple segmentations
         if self.color is not None:
-            state["segmentDefaultColor"] = self.color
+            if isinstance(self.color, str):
+                state["segmentDefaultColor"] = self.color
+            else:
+                state["segmentColors"] = {str(k): v for k, v in self.color.items()}
+
         return state
 
 

--- a/cryoet_data_portal_neuroglancer/state_generator.py
+++ b/cryoet_data_portal_neuroglancer/state_generator.py
@@ -217,7 +217,7 @@ def generate_segmentation_mask_layer(
     source: str,
     name: str | None = None,
     url: str | None = None,
-    color: str | None = "#FFFFFF",
+    color: str | dict[int, str] | None = "#FFFFFF",
     scale: float | tuple[float, float, float] = (1.0, 1.0, 1.0),
     is_visible: bool = True,
     display_bounding_box: bool = False,
@@ -238,8 +238,12 @@ def generate_segmentation_mask_layer(
         The name of the layer. If None, the name will be derived from the source.
     url: str | None, optional
         The base URL for the data. If None, the source must be a direct URL.
-    color: str, optional
+    color: str | dict[int, str] | None, optional
         The color of the points in hex format. Default is white (#FFFFFF).
+        If a dictionary is provided, the keys are the segment labels (int)
+        and the values are the colors in hex format (str) for that segment.
+        If None, the default colors will be used, which are randomly generated
+        colors by neuroglancer.
     scale: float | tuple[float, float, float], optional
         The scale/resolution of the data in metres. Ordering is XYZ.
         If a single float is provided, it will be used for all three axes.
@@ -288,7 +292,12 @@ def generate_segmentation_mask_layer(
         scale=scale,
         output_scale=output_scale,
     )
-    _validate_color(color)
+    if isinstance(color, str):
+        _validate_color(color)
+    elif color is not None:
+        for col in color.values():
+            _validate_color(col)
+
     return SegmentationJSONGenerator(
         source=source,
         name=name,


### PR DESCRIPTION
Previously the colors could only be random completely , or a single fixed color. This allows a color to be created for individual ids via a dict mapping the ID to the value